### PR TITLE
Fix RecursionError in 401 re-authentication flow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,22 @@ Changelog
 Next
 ====
 
+Version 0.4.6 - 2026-07-15
+==========================
+
+- Fixed a ``RecursionError`` in the 401 re-authentication flow: the ``reauth``
+  response hook now disables itself while it runs, so requests made during
+  ``auth()`` (login, CSRF token) and the single retry of the failed request
+  can no longer re-enter it. A 401 during authentication surfaces as an
+  ``HTTPError``, and a request that keeps returning 401 is retried only once.
+- The retried request now carries the refreshed ``Authorization`` header
+  (previously it was re-sent with the stale token, which kept failing with 401
+  and re-entered the hook indefinitely). The retry also honors the original
+  request's settings (TLS verification, timeout) instead of forcing
+  ``verify=False``.
+- ``UsernamePasswordAuth`` no longer sends a stale ``Authorization`` header to
+  the login endpoint when re-authenticating.
+
 Version 0.3.12 - 2026-04-22
 ==========================
 

--- a/src/preset_cli/auth/main.py
+++ b/src/preset_cli/auth/main.py
@@ -2,7 +2,7 @@
 Mechanisms for authentication and authorization.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from requests import Response, Session
 from requests.adapters import HTTPAdapter
@@ -41,16 +41,45 @@ class Auth:  # pylint: disable=too-few-public-methods
     # pylint: disable=invalid-name, unused-argument
     def reauth(self, r: Response, *args: Any, **kwargs: Any) -> Response:
         """
-        Catch 401 and re-auth.
+        Catch 401, re-authenticate, and retry the request once.
+
+        This hook disables itself while it runs, so requests made during
+        ``auth()`` (login, CSRF token) can never re-enter it: a 401 there
+        surfaces to the caller instead of triggering yet another
+        re-authentication. The hook is also stripped from the retried request
+        (session hooks were merged into it when it was prepared), so a second
+        401 is returned as-is instead of looping.
         """
         if r.status_code != 401:
             return r
 
+        session_hooks = self.session.hooks["response"]
+        self.session.hooks["response"] = [
+            hook for hook in session_hooks if hook != self.reauth
+        ]
         try:
-            self.auth()
-        except NotImplementedError:
-            return r
+            try:
+                self.auth()
+            except NotImplementedError:
+                return r
 
-        self.session.headers.update(self.get_headers())
-        r.request.headers.update(self.get_headers())
-        return self.session.send(r.request, verify=False)
+            # Refresh the credential headers on the session and on the request
+            # being retried. ``get_headers()`` covers mechanisms that expose
+            # credentials directly (e.g. token auths); ``Authorization`` is
+            # copied from the session for mechanisms that store the fresh token
+            # there (e.g. username/password auth) -- retrying with the stale
+            # ``Authorization`` header would just 401 again.
+            self.session.headers.update(self.get_headers())
+            r.request.headers.update(self.get_headers())
+            authorization = self.session.headers.get("Authorization")
+            if authorization is not None:
+                r.request.headers["Authorization"] = cast(str, authorization)
+
+            r.request.hooks["response"] = [
+                hook for hook in r.request.hooks["response"] if hook != self.reauth
+            ]
+            # ``kwargs`` are the original send kwargs (verify, timeout, ...),
+            # passed through by ``dispatch_hook``.
+            return self.session.send(r.request, **kwargs)
+        finally:
+            self.session.hooks["response"] = session_hooks

--- a/src/preset_cli/auth/superset.py
+++ b/src/preset_cli/auth/superset.py
@@ -15,7 +15,13 @@ class UsernamePasswordAuth(Auth):  # pylint: disable=too-few-public-methods
     Auth to Superset via username/password.
     """
 
-    def __init__(self, baseurl: URL, username: str, password: Optional[str] = None, provider: Optional[str] = None):
+    def __init__(
+        self,
+        baseurl: URL,
+        username: str,
+        password: Optional[str] = None,
+        provider: Optional[str] = None,
+    ):
         super().__init__()
 
         self.csrf_token: Optional[str] = None
@@ -37,9 +43,14 @@ class UsernamePasswordAuth(Auth):  # pylint: disable=too-few-public-methods
             "password": self.password,
             "provider": self.provider,
         }
-        if "Referer" in self.session.headers:
-            del self.session.headers["Referer"]
-        response = self.session.post(self.baseurl / "api/v1/security/login", json=body)
+        # Drop headers left over from a previous login: the login request must not
+        # carry a stale (expired) Bearer token or Referer.
+        self.session.headers.pop("Authorization", None)
+        self.session.headers.pop("Referer", None)
+        response = self.session.post(
+            self.baseurl / "api/v1/security/login",
+            json=body,
+        )
         response.raise_for_status()
         return response.json()["access_token"]
 

--- a/tests/auth/main_test.py
+++ b/tests/auth/main_test.py
@@ -2,26 +2,53 @@
 Test authentication mechanisms.
 """
 
-from pytest_mock import MockerFixture
+from typing import Dict
+
+import pytest
+from requests.exceptions import HTTPError
 from requests_mock.mocker import Mocker
 
 from preset_cli.auth.main import Auth
 
 
-def test_auth(mocker: MockerFixture) -> None:
+class TokenMintingAuth(Auth):
+    """
+    Auth that mints a new token on every ``auth()`` call.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.auth_calls = 0
+
+    def get_headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer token-{self.auth_calls}"}
+
+    def auth(self) -> None:
+        self.auth_calls += 1
+
+
+class HTTPLoginAuth(Auth):
+    """
+    Auth whose ``auth()`` performs an HTTP login through the session.
+    """
+
+    def auth(self) -> None:
+        response = self.session.post("https://example.org/login")
+        response.raise_for_status()
+        self.session.headers["Authorization"] = "Bearer fresh"
+
+
+def test_auth() -> None:
     """
     Tests for the base class ``Auth``.
     """
-    # pylint: disable=invalid-name
-    Session = mocker.patch("preset_cli.auth.main.Session")
-
     auth = Auth()
-    assert auth.session == Session()
+    assert auth.reauth in auth.session.hooks["response"]
 
 
-def test_reauth(requests_mock: Mocker) -> None:
+def test_reauth_not_implemented(requests_mock: Mocker) -> None:
     """
-    Test the ``reauth`` hook when authentication fails.
+    A 401 is returned as-is when the mechanism can't re-authenticate.
     """
     requests_mock.get("http://example.org/", status_code=401)
 
@@ -29,3 +56,73 @@ def test_reauth(requests_mock: Mocker) -> None:
     auth = Auth()
     response = auth.session.get("http://example.org/")
     assert response.status_code == 401
+    assert len(requests_mock.request_history) == 1
+
+
+def test_reauth_retries_once_with_fresh_headers(requests_mock: Mocker) -> None:
+    """
+    A 401 triggers a re-auth and a single retry carrying the fresh credentials.
+    """
+    requests_mock.get("https://example.org/", status_code=401)
+    requests_mock.get(
+        "https://example.org/",
+        request_headers={"Authorization": "Bearer token-1"},
+        json={"hello": "world"},
+    )
+
+    auth = TokenMintingAuth()
+    response = auth.session.get("https://example.org/")
+
+    assert response.status_code == 200
+    assert auth.auth_calls == 1
+    assert len(requests_mock.request_history) == 2
+    retried_request = requests_mock.request_history[1]
+    assert retried_request.headers["Authorization"] == "Bearer token-1"
+    assert auth.session.headers["Authorization"] == "Bearer token-1"
+
+
+def test_reauth_gives_up_after_one_retry(requests_mock: Mocker) -> None:
+    """
+    A request that keeps returning 401 after a successful re-auth is not
+    retried again: the second 401 is returned to the caller.
+    """
+    requests_mock.get("https://example.org/", status_code=401)
+
+    auth = TokenMintingAuth()
+    response = auth.session.get("https://example.org/")
+
+    assert response.status_code == 401
+    assert auth.auth_calls == 1
+    assert len(requests_mock.request_history) == 2
+
+
+def test_reauth_restores_the_hook(requests_mock: Mocker) -> None:
+    """
+    The hook is re-enabled after a re-auth, so a later 401 is handled too.
+    """
+    requests_mock.get("https://example.org/", status_code=401)
+
+    auth = TokenMintingAuth()
+    auth.session.get("https://example.org/")
+    auth.session.get("https://example.org/")
+
+    assert auth.auth_calls == 2
+    assert len(requests_mock.request_history) == 4
+
+
+def test_401_during_auth_does_not_reauth(requests_mock: Mocker) -> None:
+    """
+    A 401 from a request made inside ``auth()`` (e.g. a failed login) surfaces
+    to the caller instead of triggering another re-authentication.
+    """
+    requests_mock.get("https://example.org/data", status_code=401)
+    requests_mock.post("https://example.org/login", status_code=401)
+
+    auth = HTTPLoginAuth()
+    with pytest.raises(HTTPError):
+        auth.session.get("https://example.org/data")
+
+    # one data request plus one login attempt; no loop
+    assert len(requests_mock.request_history) == 2
+    # the hook is restored even though ``auth()`` raised
+    assert auth.reauth in auth.session.hooks["response"]

--- a/tests/auth/superset_test.py
+++ b/tests/auth/superset_test.py
@@ -2,7 +2,9 @@
 Test username:password authentication mechanism.
 """
 
+import pytest
 from pytest_mock import MockerFixture
+from requests.exceptions import HTTPError
 from requests_mock.mocker import Mocker
 from yarl import URL
 
@@ -88,6 +90,75 @@ def test_username_password_auth_no_csrf(requests_mock: Mocker) -> None:
     assert auth.get_headers() == {}
     assert auth.session.headers["Authorization"] == "Bearer ACCESS_TOKEN"
     assert "X-CSRFToken" not in auth.session.headers
+
+
+def test_username_password_auth_reauth_on_expired_token(requests_mock: Mocker) -> None:
+    """
+    A 401 mid-run triggers a fresh login, and the failed request is retried
+    once with the new token (not the stale one).
+    """
+    requests_mock.post(
+        "https://superset.example.org/api/v1/security/login",
+        [
+            {"json": {"access_token": "TOKEN_1"}},
+            {"json": {"access_token": "TOKEN_2"}},
+        ],
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/security/csrf_token/",
+        json={"result": "CSRF_TOKEN"},
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/chart/",
+        request_headers={"Authorization": "Bearer TOKEN_1"},
+        status_code=401,
+    )
+    requests_mock.get(
+        "https://superset.example.org/api/v1/chart/",
+        request_headers={"Authorization": "Bearer TOKEN_2"},
+        json={"result": []},
+    )
+
+    auth = UsernamePasswordAuth(
+        URL("https://superset.example.org/"),
+        "admin",
+        "password123",
+    )
+    response = auth.session.get("https://superset.example.org/api/v1/chart/")
+
+    assert response.status_code == 200
+    assert auth.session.headers["Authorization"] == "Bearer TOKEN_2"
+
+    # the re-login request must not carry the stale Bearer token
+    login_requests = [
+        request
+        for request in requests_mock.request_history
+        if request.path == "/api/v1/security/login"
+    ]
+    assert len(login_requests) == 2
+    assert "Authorization" not in login_requests[1].headers
+
+
+def test_username_password_auth_login_failure(requests_mock: Mocker) -> None:
+    """
+    A 401 from the login endpoint itself fails with an ``HTTPError`` instead
+    of looping into another re-authentication.
+    """
+    requests_mock.post(
+        "https://superset.example.org/api/v1/security/login",
+        status_code=401,
+    )
+
+    with pytest.raises(HTTPError):
+        UsernamePasswordAuth(
+            URL("https://superset.example.org/"),
+            "admin",
+            "bad-password",
+        )
+
+    # the 401 on the initial login triggers the reauth hook once; the login it
+    # attempts (with the hook disabled) fails and surfaces -- two requests, no loop
+    assert len(requests_mock.request_history) == 2
 
 
 def test_jwt_auth_superset(mocker: MockerFixture) -> None:


### PR DESCRIPTION
## Problem

The nosara `superset_consistency_check` job (weekly_sunday DAG) crashed with `RecursionError: maximum recursion depth exceeded` deep inside `preset_cli`'s auth code.

Root cause chain:

1. The `reauth` response hook re-sent the failed request through the same hooked session — so every 401 re-entered the hook recursively, with no base case.
2. On retry, the hook only refreshed `get_headers()` (the CSRF token), never the `Authorization` header that `UsernamePasswordAuth` stores on the session. After the first token expiry (~15 min into the sweep), re-login *succeeded* every time, but the retried request kept the stale Bearer token, 401'd again, and re-entered the hook until the interpreter hit the recursion limit.
3. Additionally, `auth()` itself made its login/CSRF requests through the hooked session, so a 401 from the login endpoint (e.g. bad credentials) also recursed instead of failing cleanly.

## Fix

The `reauth` hook now disables itself while it runs: it is removed from `session.hooks["response"]` for the duration of `auth()` (and restored in a `finally`), and stripped from the retried request's prepared hooks (requests merges session hooks into the `PreparedRequest` at prepare time). This eliminates every re-entry path while keeping the original single-session, hook-based design:

- A 401 during authentication (login, CSRF token) surfaces as an `HTTPError` via `raise_for_status()` instead of re-entering the hook.
- A request that keeps returning 401 after a successful re-auth is retried exactly once; the second 401 is returned to the caller.
- The retried request now carries the refreshed `Authorization` header (copied from the session, where `UsernamePasswordAuth` stores the fresh token).
- The retry reuses the original send kwargs (TLS verification, timeout, …) passed to the hook by `dispatch_hook`, instead of forcing `verify=False`.
- `UsernamePasswordAuth.get_access_token` strips the stale `Authorization` header (alongside the existing `Referer` deletion) before posting to `/api/v1/security/login`.

## Tests

- Retry happens exactly once with refreshed headers; a persistent 401 yields the 401 after exactly 2 requests (no loop); the hook is restored afterwards so a later 401 is handled too.
- A 401 during `auth()` raises `HTTPError` without re-entering, and the hook is restored even when `auth()` raises — the direct regression test for the production crash.
- Mid-run token expiry: transparent re-login, retry succeeds with the new token, and the re-login request carries no stale `Authorization` header.
- Login returning 401 at construction fails with `HTTPError` after two bounded requests (initial attempt + the hook's one re-auth attempt).
- Full suite: 703 passed. Pre-commit clean on changed files (the pylint `E0401 Unable to import 'yarl'` hook failures are pre-existing environment noise that fires on untouched files too).